### PR TITLE
Add a deprecated path for markup change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
+import classnames from 'classnames';
 import { registerBlockType } from '@wordpress/blocks';
 import { __, _x } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { link as icon } from '@wordpress/icons';
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
 import './style.scss';
 
@@ -26,7 +28,37 @@ registerBlockType( name, {
 		__('hyperlink'),
 		__('link'),
         __('tiptoppress'),
-    ],
+	],
+	deprecated: [
+		{
+			save( { attributes, className } ) {
+				const {
+					linkTarget,
+					rel,
+					title,
+					url,
+				} = attributes;
+				const buttonClasses = classnames(
+					'wp-block-hyperlink-group',
+				);
+				const wrapperClasses = classnames( className );
+
+				return (
+					<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
+						<a
+							className={ buttonClasses }
+							href={ url }
+							title={ title }
+							target={ linkTarget }
+							rel={ rel }
+						>
+							<InnerBlocks.Content />
+						</a>
+					</div>
+				);
+			},
+		},
+	],
 	example: {
 		attributes: {
 			style: {
@@ -119,7 +151,7 @@ registerBlockType( name, {
 						'tiptip/hyperlink-group-block',
 						{},
 						groupInnerBlocks
-						
+
 					);
 				},
 			},


### PR DESCRIPTION
To test the PR.
- Copy the old block markup into the block editor
```html
<!-- wp:tiptip/hyperlink-group-block -->
<div class="wp-block-tiptip-hyperlink-group-block"><a class="wp-block-hyperlink-group"><!-- wp:paragraph -->
<p>Hyperlink Group Block</p>
<!-- /wp:paragraph --></a></div>
<!-- /wp:tiptip/hyperlink-group-block -->
```
- Save/update the page to see the markup change.

Fixes https://github.com/DanielFloeter/hyperlink-group-block/issues/5