### PR TITLE
Update plugin URL to use correct slug

### DIFF
--- a/hyperlink-group-block.php
+++ b/hyperlink-group-block.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:     Hyperlink Group Block
- * Plugin URI:      https://wordpress.org/plugins/hyperlink-group/
+ * Plugin URI:      https://wordpress.org/plugins/hyperlink-group-block/
  * Description:     Combine blocks into a group wrapped with an hyperlink (&lt;a&gt;).
  * Version:         1.0.8
  * Author:          TipTopPress


### PR DESCRIPTION
Changes https://wordpress.org/plugins/hyperlink-group/ to https://wordpress.org/plugins/hyperlink-group-block/ since the first one redirects to the search results.